### PR TITLE
Fix heap/quick/count sort bugs and add comprehensive sort tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.10</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 
 

--- a/src/com/jnlzw/lzwtool/commom/algorithms/Sort.java
+++ b/src/com/jnlzw/lzwtool/commom/algorithms/Sort.java
@@ -29,6 +29,7 @@ public class Sort {
 
     //归并排序
     public <T> void mergeSort(T[] num, Comparator<? super T> c) {
+        if (num == null || num.length < 2) return;
         perMergeSort(num, 0, num.length - 1, c);
     }
 
@@ -51,6 +52,7 @@ public class Sort {
 
     //堆排序
     public <T> void heapSort(T[] num, Comparator<? super T> c) {
+        if (num == null || num.length < 2) return;
         int N = num.length;
         buildMaxHeap(num, c);
         for (int i = N - 1; i > 0; i--) {
@@ -68,7 +70,7 @@ public class Sort {
         if (index * 2 + 1 < length && c.compare(num[largest], num[index * 2 + 1]) > 0) {
             largest = index * 2 + 1;
         }
-        if (index * 2 + 2 < length && c.compare(num[largest], num[index * 2 + 1]) > 0) {
+        if (index * 2 + 2 < length && c.compare(num[largest], num[index * 2 + 2]) > 0) {
             largest = index * 2 + 2;
         }
         if (largest != index) {
@@ -88,6 +90,7 @@ public class Sort {
 
     //快速排序 随机数优化
     public <T> void quickSort(T[] num, Comparator<? super T> c) {
+        if (num == null || num.length < 2) return;
         perQuickSort(num, 0, num.length - 1, c);
     }
 
@@ -101,19 +104,23 @@ public class Sort {
 
     private <T> int partition(T[] num, int p, int r, Comparator<? super T> c) {
         Random random = new Random();
-        //随机选取key值，防止算法退化为冒泡
-        T key = num[p + random.nextInt(r - p)];
+        int pivotIndex = p + random.nextInt(r - p + 1);
+        T t = num[pivotIndex];
+        num[pivotIndex] = num[r];
+        num[r] = t;
+        T pivot = num[r];
         int i = p;
         for (int j = p; j < r; j++) {
-            if (c.compare(num[j], key) < 0) {
-                T t = num[j];
+            if (c.compare(num[j], pivot) < 0) {
+                T tmp = num[j];
                 num[j] = num[i];
-                num[i] = t;
-                i = i + 1;
+                num[i] = tmp;
+                i++;
             }
         }
-        num[r] = num[i];
-        num[i] = key;
+        T tmp = num[i];
+        num[i] = num[r];
+        num[r] = tmp;
         return i;
     }
 
@@ -121,18 +128,22 @@ public class Sort {
     //计数排序
     //计数排序的count数组长度为10000，num数组内的数字最大值为9999，可以更改。
     public void countSort(Integer[] num) {
+        if (num == null || num.length < 2) return;
         int N = num.length;
-        int[] count = new int[10000];
-        for (int i = 0; i < 100; i++) count[i] = 0;
-        for (int value : num) count[value]++;
-        for (int i = 98; i >= 0; i--) count[i] += count[i + 1];
-        Integer[] tempNum = new Integer[N];
+        int max = num[0];
         for (int value : num) {
+            if (value > max) max = value;
+        }
+        int[] count = new int[max + 1];
+        for (int value : num) count[value]++;
+        for (int i = 1; i < count.length; i++) count[i] += count[i - 1];
+        Integer[] tempNum = new Integer[N];
+        for (int i = N - 1; i >= 0; i--) {
+            int value = num[i];
             tempNum[count[value] - 1] = value;
             count[value]--;
         }
         System.arraycopy(tempNum, 0, num, 0, N);
-        reversalArray(num);
     }
 
 

--- a/src/test/java/com/jnlzw/lzwtool/commom/algorithms/SortTest.java
+++ b/src/test/java/com/jnlzw/lzwtool/commom/algorithms/SortTest.java
@@ -1,0 +1,73 @@
+package com.jnlzw.lzwtool.commom.algorithms;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class SortTest {
+
+    private final Sort sort = new Sort();
+    private final Comparator<Integer> asc = Integer::compareTo;
+
+    @Test
+    void insertionSortCases() {
+        assertCases((arr) -> sort.insertionSort(arr, asc));
+    }
+
+    @Test
+    void mergeSortCases() {
+        assertCases((arr) -> sort.mergeSort(arr, asc));
+    }
+
+    @Test
+    void heapSortCases() {
+        assertCases((arr) -> sort.heapSort(arr, asc));
+    }
+
+    @Test
+    void quickSortCases() {
+        assertCases((arr) -> sort.quickSort(arr, asc));
+    }
+
+    @Test
+    void countSortCases() {
+        assertCases(sort::countSort);
+    }
+
+    private void assertCases(SortExecutor executor) {
+        Integer[] empty = new Integer[]{};
+        executor.sort(empty);
+        assertArrayEquals(new Integer[]{}, empty);
+
+        Integer[] dup = new Integer[]{3, 1, 3, 2, 2};
+        executor.sort(dup);
+        assertArrayEquals(new Integer[]{1, 2, 2, 3, 3}, dup);
+
+        Integer[] sorted = new Integer[]{1, 2, 3, 4, 5};
+        executor.sort(sorted);
+        assertArrayEquals(new Integer[]{1, 2, 3, 4, 5}, sorted);
+
+        Integer[] reverse = new Integer[]{5, 4, 3, 2, 1};
+        executor.sort(reverse);
+        assertArrayEquals(new Integer[]{1, 2, 3, 4, 5}, reverse);
+
+        Integer[] randomLarge = new Integer[200];
+        Random random = new Random(42);
+        for (int i = 0; i < randomLarge.length; i++) {
+            randomLarge[i] = random.nextInt(1000);
+        }
+        Integer[] expected = randomLarge.clone();
+        Arrays.sort(expected);
+        executor.sort(randomLarge);
+        assertArrayEquals(expected, randomLarge);
+    }
+
+    @FunctionalInterface
+    private interface SortExecutor {
+        void sort(Integer[] arr);
+    }
+}


### PR DESCRIPTION
### Motivation
- Correct multiple correctness and edge-case issues in the sorting utilities so algorithms behave reliably on common inputs and do not rely on hard-coded bounds. 
- Add minimal reproducible unit tests that exercise empty arrays, duplicates, sorted/reverse arrays and larger random inputs to prevent regressions. 

### Description
- Fixed `maxHeapify` right-child comparison to use index `index * 2 + 2` and preserved the comparator direction used by this heap implementation in `Sort.java`. 
- Rewrote `partition` to pick a random pivot index, swap it with `r`, and perform a standard Lomuto partition so the pivot value is not overwritten during partitioning. 
- Reworked `countSort` to compute the `count` array size from the input maximum value, build prefix sums from `count.length`, and fill output in stable order (iterating backward), removing hard-coded constants. 
- Added null/length guards (`if (num == null || num.length < 2) return;`) to `mergeSort`, `heapSort`, `quickSort`, and `countSort`, and added a JUnit test `src/test/java/com/jnlzw/lzwtool/commom/algorithms/SortTest.java` covering the standard cases; also added `spring-boot-starter-test` to `pom.xml` for test execution. 

### Testing
- Added unit tests under `src/test/java/com/jnlzw/lzwtool/commom/algorithms/SortTest.java` that run the same validation cases against `insertionSort`, `mergeSort`, `heapSort`, `quickSort`, and `countSort`. 
- Ran `mvn test -q` to execute automated tests, but the build failed in this environment due to Maven dependency resolution error fetching the parent POM (`org.springframework.boot:spring-boot-starter-parent:2.2.1.RELEASE`) from Maven Central (HTTP 403), so tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1beba438c832ca2c78af707aec3db)